### PR TITLE
When adding new events, we need to sort the entire list

### DIFF
--- a/src/components/Events.js
+++ b/src/components/Events.js
@@ -17,8 +17,8 @@ compose(
           ...s,
           ...(items || []).filter(event =>
             event.organizer && +Date.now() < +new Date(event.end.dateTime)
-          ).sort((a, b) => +new Date(a.start.dateTime) - +new Date(b.start.dateTime)),
-        ])
+          ),
+        ].sort((a, b) => +new Date(a.start.dateTime) - +new Date(b.start.dateTime)))
       })
     },
   })


### PR DESCRIPTION
## Summary of Changes
Previously only the events being added were sorted. This has a slight performance penalty because the overall list will be sorted more (once when each `fetch` finishes. It could probably be refactored to await all of the fetches finishing and then sorting once but this is a good first step

## Testing Done
Tested using local development server. All events were sorted by date as expected. See image below

![screen shot 2017-02-15 at 6 11 50 pm](https://cloud.githubusercontent.com/assets/6757853/22999685/d0aae018-f3aa-11e6-9667-88ebf89e4df3.png)

Resolves #10 