### PR TITLE
Static markdown page support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
   "dependencies": {
     "babel-polyfill": "^6.23.0",
     "color": "^1.0.3",
-    "glamor": "^2.20.12",
-    "prop-types": "^15.5.8",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-markdown": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,11 @@
   "dependencies": {
     "babel-polyfill": "^6.23.0",
     "color": "^1.0.3",
+    "glamor": "^2.20.12",
+    "prop-types": "^15.5.8",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
+    "react-markdown": "^2.5.0",
     "react-rotating-text": "^1.2.0",
     "react-router-dom": "^4.1.1",
     "recompose": "^0.23.1",

--- a/public/test.md
+++ b/public/test.md
@@ -1,0 +1,3 @@
+# Test
+
+Hello World!

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,11 @@
 // @flow
 
 import React from 'react'
-import Splash from './components/Splash'
-import Events from './components/Events'
-import ErrorPage from './components/ErrorPage'
 import { BrowserRouter, Switch, Route } from 'react-router-dom'
+import EventsPage from './components/EventsPage'
+import StaticPage from './components/StaticPage'
+import ErrorPage from './components/ErrorPage'
+import Splash from './components/Splash'
 import theme from './theme'
 
 let App = () => (
@@ -13,12 +14,11 @@ let App = () => (
       <Switch>
         <Route
           exact path="/"
-          component={() =>
-            <div>
-              <Splash />
-              <Events />
-            </div>
-          }
+          component={EventsPage}
+        />
+        <Route
+          exact path="/p(age)?/:page"
+          component={StaticPage}
         />
         <Route
           exact path="/workshop"

--- a/src/components/ErrorPage.js
+++ b/src/components/ErrorPage.js
@@ -1,15 +1,20 @@
 import React from 'react'
+import styled from 'styled-components'
 import Splash from './Splash'
+
+const Page = styled.section`
+  padding: 20px;
+  max-width: 750px;
+  margin: 0 auto;
+`
 
 let ErrorPage = () => (
   <div>
     <Splash />
-    <div>
-      Uh oh! Something went wrong.
-    </div>
-    <div>
-      [Insert witty gif here]
-    </div>
+    <Page>
+      <p>Uh oh! Something went wrong.</p>
+      <p>[Insert witty gif here]</p>
+    </Page>
   </div>
 )
 

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import Splash from './Splash'
+import Events from './Events'
+
+let EventPage = () =>
+  <div>
+    <Splash />
+    <Events />
+  </div>
+
+export default EventPage

--- a/src/components/StaticPage.js
+++ b/src/components/StaticPage.js
@@ -1,0 +1,81 @@
+import React, { Component } from 'react'
+import ReactMarkdown from 'react-markdown'
+import { css } from 'glamor'
+import Splash from './Splash'
+
+class StaticPage extends Component {
+  constructor (props) {
+    super(props)
+    
+    let page = ``
+
+    // Lets not allow people to browse the file system,
+    //  only use the word in the path
+    //
+    // props.params is an Object... but has array like
+    //  keys (0, 1, etc) very weird way to parse params, 
+    //  I dont think I'm doing this correctly
+    if (props.match && 
+      props.match.params && 
+      props.match.params.hasOwnProperty(`page`)) {
+      
+      let buffer = props.match.params.page.match(/\w+/g)
+      
+      if (buffer.length > 0) {
+        page = buffer[0]
+      } else {
+        // Or error out?
+        this.state.history.replace({ pathname: `/404` })
+      }
+    }
+ 
+    this.state = {
+      page,
+      content: ``,
+      history: props.history || {},
+    }  
+  }
+
+  componentDidMount () {
+    // Make request to get the data
+    fetch(`/${this.state.page}.md`)
+      .then((response) => response.text())
+      .then((data) => {
+        // Hack to work around react-router inability to send 404 status
+        // code for 404s. If we see a <head> tag in the response, its probably
+        // not Markdown...
+        if (data.match(/<head>/g)) {
+          throw new Error(`404 Not Found`)
+        }
+
+        // Update the state with the content so we re-render
+        this.setState({ content: data })
+      })
+      .catch(() => {
+        const { history } = this.state
+        // Or error out?
+        history.replace({ pathname: `/404` })
+      })
+  }
+
+  render () {
+    const { content } = this.state
+
+    return (
+      <div>
+        <Splash />
+        <div className={page}>
+          <ReactMarkdown source={content} />
+        </div>
+      </div>
+    )
+  }
+}
+
+const page = css({
+  padding: `20px`,
+  maxWidth: `750px`,
+  margin: `0 auto`,
+})
+
+export default StaticPage

--- a/src/components/StaticPage.js
+++ b/src/components/StaticPage.js
@@ -1,61 +1,29 @@
 import React, { Component } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { css } from 'glamor'
+import styled from 'styled-components'
 import Splash from './Splash'
 
+const basePath = process.env.NODE_ENV === `development` ? ``
+  : `https://raw.githubusercontent.com/torontojs/torontojs.com/gh-pages`
+
+const Page = styled.section`
+  padding: 20px;
+  max-width: 750px;
+  margin: 0 auto;
+`
+
 class StaticPage extends Component {
-  constructor (props) {
-    super(props)
-    
-    let page = ``
+  state = { content: `` }
 
-    // Lets not allow people to browse the file system,
-    //  only use the word in the path
-    //
-    // props.params is an Object... but has array like
-    //  keys (0, 1, etc) very weird way to parse params, 
-    //  I dont think I'm doing this correctly
-    if (props.match && 
-      props.match.params && 
-      props.match.params.hasOwnProperty(`page`)) {
-      
-      let buffer = props.match.params.page.match(/\w+/g)
-      
-      if (buffer.length > 0) {
-        page = buffer[0]
-      } else {
-        // Or error out?
-        this.state.history.replace({ pathname: `/404` })
-      }
-    }
- 
-    this.state = {
-      page,
-      content: ``,
-      history: props.history || {},
-    }  
-  }
-
-  componentDidMount () {
-    // Make request to get the data
-    fetch(`/${this.state.page}.md`)
+  async componentDidMount () {
+    let data = await fetch(`${basePath}/${this.props.match.params.page}.md`)
       .then((response) => response.text())
-      .then((data) => {
-        // Hack to work around react-router inability to send 404 status
-        // code for 404s. If we see a <head> tag in the response, its probably
-        // not Markdown...
-        if (data.match(/<head>/g)) {
-          throw new Error(`404 Not Found`)
-        }
 
-        // Update the state with the content so we re-render
-        this.setState({ content: data })
-      })
-      .catch(() => {
-        const { history } = this.state
-        // Or error out?
-        history.replace({ pathname: `/404` })
-      })
+    if (data.match(/<head>/g)) {
+      this.props.history.replace({ pathname: `/404` })
+    } else {
+      this.setState({ content: data })
+    }
   }
 
   render () {
@@ -64,18 +32,12 @@ class StaticPage extends Component {
     return (
       <div>
         <Splash />
-        <div className={page}>
+        <Page>
           <ReactMarkdown source={content} />
-        </div>
+        </Page>
       </div>
     )
   }
 }
-
-const page = css({
-  padding: `20px`,
-  maxWidth: `750px`,
-  margin: `0 auto`,
-})
 
 export default StaticPage


### PR DESCRIPTION
So this is to support static Markdown files and make them look like they're pages that we've built into the site. This will allow us to build out pages quickly, that don't require us to create React components for. For example, the About page.

We can now create `*.md` Markdown files in `public/` and link to it by going to: 
```
http://torontojs.com/page/$MarkdownFile
```
Where `$MarkdownFile = test` which will load `public/test.md`

![screenshot 2017-04-25 at 20 28 38](https://cloud.githubusercontent.com/assets/563301/25413121/ccdbc408-29f5-11e7-852c-eee0d4dfdfe8.png)
_(I've included test.md in the PR but can remove it if we need to.)_

### Considerations:
- Theres an issue with react-router where even 404 pages return status code 200. This causes an issue with pulling Markdown files that dont exist, If for example you try to goto `http://torontojs.com/page/asdfasdfasdfa` and `asdfasdfasdfa.md` doesnt exist we return the 404 react page in the content area.. on the Static page (i.e. you actually see source code rendered in `<p>` tags). I've created a workaround to Regex for `<head>` and if this exists, we can assume the Markdown file doesnt exist, and redirect to the proper 404 page. [Line 45 of StaticPage.js](https://github.com/torontojs/torontojs.com/pull/21/files#diff-b34a78fa336519998277097a24915d14R45)
- There is an issue with the react-markdown library that causes problem with rendering inline HTML. [Link to issue on react-markdown repo](https://github.com/rexxars/react-markdown#inline-html-is-broken)

Issue: #18 