### PR TITLE
change header icon colour on hover

### DIFF
--- a/src/components/Splash.js
+++ b/src/components/Splash.js
@@ -17,29 +17,21 @@ let Header = styled(Row)`
   z-index: 1;
 `
 
-let SlackLink = styled.a`
+let Link = styled.a`
   color: white;
   padding: 10px;
   display: flex;
   align-items: center;
   text-decoration: none;
-`
-
-let GithubLink = styled.a`
-  color: white;
-  padding: 10px;
-  display: flex;
-  align-items: center;
-  text-decoration: none;
+  &:hover {
+    color: rgb(255, 248, 84);
+  }
 `
 
 let LinkText = styled.span`
   font-weight: bold;
   padding-left: 10px;
   transition: color 0.2s ease;
-  &:hover {
-    color: rgb(255, 248, 84);
-  }
   @media (max-width: 700px) {
     display: none;
   }
@@ -92,18 +84,18 @@ type Props = {
 export default ({ backgroundColor = theme.primary, page = `TORONTO` }: Props) => (
   <Container backgroundColor={backgroundColor}>
     <Header>
-      <SlackLink href="http://slack.torontojs.com/" target="_blank">
+      <Link href="http://slack.torontojs.com/" target="_blank">
         <SlackIcon style={{ width: `30px` }} />
         <LinkText>Join us on Slack</LinkText>
-      </SlackLink>
-      <GithubLink href="https://github.com/torontojs/torontojs.com" target="_blank">
+      </Link>
+      <Link href="https://github.com/torontojs/torontojs.com" target="_blank">
         <Octocat width="30px" />
         <LinkText>Contribute to this site</LinkText>
-      </GithubLink>
-      <GithubLink href="https://www.youtube.com/channel/UC1samyyfqiKmOT6fq3uVO1A" target="_blank">
+      </Link>
+      <Link href="https://www.youtube.com/channel/UC1samyyfqiKmOT6fq3uVO1A" target="_blank">
         <i className="fa fa-youtube-play" style={{ fontSize: `32px` }} />
         <LinkText>Tech Talks</LinkText>
-      </GithubLink>
+      </Link>
     </Header>
     <InnerContainer>
       <TitleContainer>

--- a/src/components/svg/Octocat.js
+++ b/src/components/svg/Octocat.js
@@ -1,5 +1,5 @@
 import React from 'react'
-export default ({ width = `100%`, height = `100%`, fill = `white`, ...props }) => (
+export default ({ width = `100%`, height = `100%`, fill = `currentColor`, ...props }) => (
   <svg width={width} height={height} viewBox="0 0 136 133" version="1.1" {...props}>
     <g transform="matrix(4.16667,0,0,4.16667,-568,-1381.06)">
       <path


### PR DESCRIPTION
- adds colour change to icon in header link
- consolidates `GithubLink` and `SlackLink` styled components

The thinking was to give it a hover effect for desktop browsers on smaller viewports. Attached gif of result.

![icons](https://user-images.githubusercontent.com/22686684/47122038-1c0c2580-d243-11e8-9ed8-10baae6ea572.gif)