### PR TITLE
Update Slack Link

### DIFF
--- a/src/components/Splash.js
+++ b/src/components/Splash.js
@@ -87,7 +87,7 @@ const speakerFormLink = `https://docs.google.com/forms/d/e/${speakerFormId}/view
 export default ({ backgroundColor = theme.primary, page = `TORONTO` }: Props) => (
   <Container backgroundColor={backgroundColor}>
     <Header>
-      <Link href='http://slack.torontojs.com/' target='_blank'>
+      <Link href='https://join.slack.com/t/torontojs/shared_invite/zt-zgi31snl-omO3tXSZ0Q7zqN9WBQSf8Q' target='_blank'>
         <SlackIcon style={{ width: `30px` }} />
         <LinkText>Join us on Slack</LinkText>
       </Link>


### PR DESCRIPTION
The old Slack bot has broken. Way back when we first got Slack setup, there was no way of inviting folks other than via their API. Therefore, we needed a way of programmatically inviting folks for which there was a Heroku bot created to accommodate.

Since then, Slack appears to just have a Shared Invite feature. I've updated the link on the website to use that.

Fixes #93 