### PR TITLE
Issue 94: Fix incident reporting form

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 # **[TorontoJS.com](http://torontojs.com/)**
 
+### Overview of the Repo
+
+|-- build // deployable contents that are gitignored but will show up locally.
+|-- flow-typed
+|-- public
+  |-- images
+  |-- pages // contains markdown content that appears after `torontojs.com/p/`
+|-- src
+  |-- components // `Splash.js` contains navigation links
+  |-- data
+  |-- theme
+  ...
+  App.js // top level app entry point
+  index.js
+  .travis.yml
+  package.json
+  README.md -- You are here.
 ### Add your meetup to our events feed
 
 If you use meetup.com to host your events, then you can create a public Google Calendar Feed with the following steps:

--- a/public/index.html
+++ b/public/index.html
@@ -88,6 +88,7 @@
         }
       }(window.location))
     </script>
+    
     <!-- End Single Page Apps for GitHub Pages -->
 
   </head>

--- a/public/pages/code_of_conduct.md
+++ b/public/pages/code_of_conduct.md
@@ -5,16 +5,16 @@ for events, meetups, and conferences about the excitement, joy, and surprise of
 programming, especially Javascript!
 
 We value the participation of each member of the community and want
-everyone to have an enjoyable and fulfilling experience. 
+everyone to have an enjoyable and fulfilling experience.
 All participants of our online and in-person gatherings are expected to show respect
-and courtesy to other attendees during any Toronto JS event, online discussion, meetup, 
+and courtesy to other attendees during any Toronto JS event, online discussion, meetup,
 or conference, whether officially sponsored by Toronto JS or not.
 
 All attendees, speakers, exhibitors, organizers and volunteers at any
 Toronto JS event are expected to observe the following Code of
 Conduct. Organizers will enforce this code through the community and throughout events.
 
-**Why have a code of conduct?** 
+**Why have a code of conduct?**
 Not because we feel like we're expected to have one, not because someone told us to, and not because we
 heard somewhere that it was important for some reason -- but **as part
 of an intentional effort to define the culture of Toronto JS**.
@@ -38,7 +38,9 @@ Thank you for helping us create a welcoming space for all.
 <br />
 
 ## THE LONGER VERSION
+
 ### Welcoming behavior
+
 Examples of behavior that contributes to creating a positive environment include:
 
 - Using welcoming and inclusive language
@@ -50,15 +52,17 @@ Examples of behavior that contributes to creating a positive environment include
 - Showing empathy towards other community members
 
 ### Unacceptable behavior
+
 The following types of behavior are unacceptable at Toronto JS, both online and in-person, and constitute code of conduct violations.
 
 ### Abusive behavior
+
 - Harassment: offensive verbal comments related to gender,
-sexual orientation, disability, physical appearance, body size, race,
-religion, sexual images in public spaces, deliberate intimidation,
-stalking, following, harassing photography or recording, sustained
-disruption of talks or other events, inappropriate physical contact or telecommunication,
-derisive comments regarding technical background, and unwelcome sexual or romantic attention.
+  sexual orientation, disability, physical appearance, body size, race,
+  religion, sexual images in public spaces, deliberate intimidation,
+  stalking, following, harassing photography or recording, sustained
+  disruption of talks or other events, inappropriate physical contact or telecommunication,
+  derisive comments regarding technical background, and unwelcome sexual or romantic attention.
 
 - Threats: threatening someone physically or verbally. For example, threatening to publicize sensitive information about someone’s personal life.
 
@@ -72,7 +76,7 @@ derisive comments regarding technical background, and unwelcome sexual or romant
 
 Participants asked to stop any harassing or malicious behavior are expected to comply immediately.
 
-Be careful in the words that you choose. Excessive swearing, trolling or the incessant posting of inflammatory comments, sexist, homophobic, transphobic, racist, ableist or otherwise exclusionary jokes can be offensive and hostile towards those around you. 
+Be careful in the words that you choose. Excessive swearing, trolling or the incessant posting of inflammatory comments, sexist, homophobic, transphobic, racist, ableist or otherwise exclusionary jokes can be offensive and hostile towards those around you.
 
 If a participant engages in behavior that violates our anti-harassment policy or code of conduct, Toronto JS organizers may take any action they deem appropriate, including warning the offender or expulsion from the
 event, gathering or Toronto JS online community.
@@ -93,15 +97,19 @@ learning environment, and we'd like Toronto JS to share that environment.
 These rules are intended to be lightweight, and to make more explicit certain social norms that are normally implicit. Most of our social rules really boil down to "don't be a jerk" or "don't be annoying." Of course, almost nobody sets out to be a jerk or annoying, so telling people not to be jerks isn't a very productive strategy. That's why our social rules are designed to curtail specific behavior we've found to be destructive to a supportive, productive, and fun learning environment.
 
 ### No feigning surprise
+
 The first rule means you shouldn't act surprised when people say they don't know something. This applies to both technical things ("What?! I can't believe you don't know what the stack is!") and non-technical things ("You don't know who RMS is?!"). Feigning surprise has absolutely no social or educational benefit: When people feign surprise, it's usually to make them feel better about themselves and others feel worse. And even when that's not the intention, it's almost always the effect. As you've probably already guessed, this rule is tightly coupled to our belief in the importance of people feeling comfortable saying "I don't know" and "I don't understand."
 
 ### No well-actually's
+
 A well-actually happens when someone says something that's almost - but not entirely - correct, and you say, "well, actually…" and then give a minor correction. This is especially annoying when the correction has no bearing on the actual conversation. This doesn't mean that Toronto JS isn't about truth-seeking or that we don't care about being precise. Almost all well-actually's in our experience are about grandstanding, not truth-seeking. (Source: [Miguel de Icaza](http://tirania.org/))
 
 ### No back-seat driving (in irl, face-to-face contexts)
+
 If you overhear people working through a problem, please don't intermittently lob advice across the room. This can lead to a "too many cooks" problem, but more important, it can be rude and disruptive to half-participate in a conversation. This isn't to say you shouldn't help, offer advice, or join conversations. On the contrary, we encourage all those things. Rather, it just means that when you help or work with others, you should fully engage and not butt in sporadically.
 
 ### No subtle "-isms"
+
 Our last social rule bans subtle racism, sexism, homophobia, transphobia, ableism and other kinds of bias. This one is different from the rest, because it covers a class of behaviors instead of one very specific pattern.
 
 Subtle -isms are small things that make others feel unwelcome, things that we all sometimes do by mistake. For example, saying "It's so easy my grandmother could do it" is a subtle -ism. Like the other three social rules, this one is often accidentally broken. Like the other three, it's not a big deal to mess up – you just apologize and move on.
@@ -118,6 +126,7 @@ Moderators will not act on complaints regarding:
 We want Toronto JS to be a space with as little bigotry or oppression as possible. Therefore, if you see sexism, racism, or outrage at such things outside Toronto JS and also do not experience such issues directly yourself, please don't bring it in for discussion. For example, don't start a discussion of the latest offensive comment from Random Tech Person Y. For many people, especially those who may have spent time in unpleasant work environments, these conversations can turn into long threads that become distracting and disheartening. At Toronto JS, we want to remove as many distractions as possible for marginalized people so they can focus on enjoying programming. There are many places in the world to discuss and debate these issues, but there are few where they can avoid them. We want Toronto JS to be one of those places.
 
 ### Why have social rules?
+
 The goal isn't to burden everyone with a bunch of annoying rules, or to give us a stick to bludgeon people with for "being bad." Rather, these rules are designed to help all of us build a pleasant, productive, and fearless community.
 
 If someone says, "hey, you just feigned surprise," or "that's subtly sexist," don't worry. Just apologize, reflect for a second, and move on. It doesn't mean you're a "bad" person, or even a "bad" community member. As we said above, these rules are meant to be guidelines. We've all done these things before.
@@ -130,6 +139,7 @@ organizers or moderators.
 <br />
 
 ## CONTACT INFORMATION
+
 If you have any concerns around social conduct or notice that someone may be the target harassment or oppressive behaviour, please reach out to a Toronto JS organizer or volunteer. Please contact
 [a member of Toronto JS organizers or volunteer staff](/p/volunteers). You
 can use the below form to contact us, with or without your name.
@@ -141,17 +151,28 @@ experiencing harassment to feel safe during events and at all times in our onlin
 
 ## REPORT A VIOLATION <br />(with or without your name)
 
-<form action="https://formspree.io/organizers@torontojs.com" method="POST">
+Please provide the following information:
 
-<label for="code of conduct violation">Code of Conduct violation </label>
-<textarea type="text" name="code of conduct violation" rows="5" cols="80" style="width: 100%"></textarea><br />
-<label for="_replyto">Your email (optional) </label>
-<input type="email" name="_replyto">
+- the time and place the harassment took place
+- the member(s) involved in the event
+- any surrounding details you think are relevant to the report
 
-<input type="submit" value="Send">
+<form
+  action="https://formspree.io/f/mayvyvzk"
+  method="POST"
+  width="100%"
+>
+<label for="_replyto">
+    Email
+    <input type="email" name="_replyto">
+  </label><br>
+  <label>
+    Description<br>
+  <textarea name="message" rows="5" cols="80" ></textarea>
+  </label><br>
+  <!-- your other form fields go here -->
+  <button type="submit">Send</button>
 </form>
-
-<br />
 
 ## LICENSE
 

--- a/public/pages/report.md
+++ b/public/pages/report.md
@@ -1,0 +1,26 @@
+## REPORT A VIOLATION <br />(with or without your name)
+
+Did you experience something awry or questionable at a Toronto JS event, or on our discussion channels? Feel free to direct others to our [Code Of Conduct](https://torontojs.com/p/code_of_conduct). Our organizers, moderators and volunteers want to maintain a welcoming environment free of abuse, harassment, or discrimination.
+
+Please provide the following information:
+
+- the time and place the harassment took place
+- the member(s) involved in the event
+- any surrounding details you think are relevant to the report
+
+<form
+  action="https://formspree.io/f/mayvyvzk"
+  method="POST"
+  width="100%"
+>
+<label for="_replyto">
+    Email
+    <input type="email" name="_replyto">
+  </label><br>
+  <label>
+    Description<br>
+  <textarea name="message" rows="5" cols="80" ></textarea>
+  </label><br>
+  <!-- your other form fields go here -->
+  <button type="submit">Send</button>
+</form>

--- a/src/App.js
+++ b/src/App.js
@@ -1,35 +1,27 @@
 // @flow
 
-import React from 'react'
-import { BrowserRouter, Switch, Route } from 'react-router-dom'
-import EventsPage from './components/EventsPage'
-import StaticPage from './components/StaticPage'
-import ErrorPage from './components/ErrorPage'
-import Splash from './components/Splash'
-import theme from './theme'
+import React from "react"
+import { BrowserRouter, Switch, Route } from "react-router-dom"
+import EventsPage from "./components/EventsPage"
+import StaticPage from "./components/StaticPage"
+import ErrorPage from "./components/ErrorPage"
+import Splash from "./components/Splash"
+import theme from "./theme"
 
 let App = () => (
   <BrowserRouter>
     <div>
       <Switch>
+        <Route exact path="/" component={EventsPage} />
+        <Route exact path="/p(age)?/:page" component={StaticPage} />
         <Route
-          exact path="/"
-          component={EventsPage}
-        />
-        <Route
-          exact path="/p(age)?/:page"
-          component={StaticPage}
-        />
-        <Route
-          exact path="/workshop"
-          component={() =>
+          exact
+          path="/workshop"
+          component={() => (
             <div>
-              <Splash
-                backgroundColor={theme.secondary}
-                page="WORKSHOP"
-              />
+              <Splash backgroundColor={theme.secondary} page="WORKSHOP" />
             </div>
-          }
+          )}
         />
         <Route component={ErrorPage} />
       </Switch>

--- a/src/components/Splash.js
+++ b/src/components/Splash.js
@@ -9,127 +9,141 @@ import SlackIcon from "./svg/SlackIcon"
 import Octocat from "./svg/Octocat"
 
 let Row = styled.div`
-	display: flex;
+  display: flex;
 `
 
 let Header = styled(Row)`
-	position: relative;
-	z-index: 1;
+  position: relative;
+  z-index: 1;
 `
 
 let Link = styled.a`
-	color: white;
-	padding: 10px;
-	display: flex;
-	align-items: center;
-	text-decoration: none;
-	&:hover {
-		color: rgb(255, 248, 84);
-	}
+  color: white;
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  &:hover {
+    color: rgb(255, 248, 84);
+  }
 `
 
 let LinkText = styled.span`
-	font-weight: bold;
-	padding-left: 10px;
-	transition: color 0.2s ease;
-	@media (max-width: 700px) {
-		display: none;
-	}
+  font-weight: bold;
+  padding-left: 10px;
+  transition: color 0.2s ease;
+  @media (max-width: 700px) {
+    display: none;
+  }
 `
 
 let InnerContainer = styled.div`
-	margin: 0 auto;
-	max-width: 1000px;
+  margin: 0 auto;
+  max-width: 1000px;
 `
 
 let TitleContainer = styled.div`
-	display: flex;
-	justify-content: center;
-	flex-direction: column;
-	align-items: center;
-	font-family: ${theme.fancyFont};
-	color: white;
-	padding: 100px 0 25px;
-	z-index: 1;
-	position: relative;
-	letter-spacing: 4px;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  font-family: ${theme.fancyFont};
+  color: white;
+  padding: 100px 0 25px;
+  z-index: 1;
+  position: relative;
+  letter-spacing: 4px;
 `
 
 let Container = styled.div`
-	height: 80vh;
-	background-color: ${(props) => props.backgroundColor || theme.primary};
-	position: relative;
+  height: 80vh;
+  background-color: ${(props) => props.backgroundColor || theme.primary};
+  position: relative;
 `
 
 let Tower = styled(Logo)`
-	position: absolute;
-	bottom: 0;
-	max-width: 600px;
+  position: absolute;
+  bottom: 0;
+  max-width: 600px;
 `
 
 let Title = styled.div`
-	font-size: 35px;
-	margin-bottom: 10px;
+  font-size: 35px;
+  margin-bottom: 10px;
 `
 
 let Rotator = styled(ReactRotatingText)`
-	font-size: 26px;
+  font-size: 26px;
 `
 
 type Props = {
-	backgroundColor?: string,
-	page?: string,
-}
+  backgroundColor?: string,
+  page?: string,
+};
 
 const speakerFormId = `1FAIpQLSc_ZA0ElHLsMedjdQjZechw5H1RJNhG1DZxtFTsqhkdut3eFg`
 const speakerFormLink = `https://docs.google.com/forms/d/e/${speakerFormId}/viewform?usp=sf_link`
 
-export default ({ backgroundColor = theme.primary, page = `TORONTO` }: Props) => (
-  <Container backgroundColor={backgroundColor}>
-    <Header>
-      <Link href='https://join.slack.com/t/torontojs/shared_invite/zt-zgi31snl-omO3tXSZ0Q7zqN9WBQSf8Q' target='_blank'>
-        <SlackIcon style={{ width: `30px` }} />
-        <LinkText>Join us on Slack</LinkText>
-      </Link>
-      <Link href='http://meetup.com/torontojs' target='_blank'>
-        <i className='fa fa-meetup' style={{ fontSize: `32px` }} />
-        <LinkText>Join us on Meetup</LinkText>
-      </Link>
-      <Link href='https://github.com/torontojs/torontojs.com' target='_blank'>
-        <Octocat width='30px' />
-        <LinkText>Contribute to this site</LinkText>
-      </Link>
-      <Link
-        href='https://www.youtube.com/channel/UC1samyyfqiKmOT6fq3uVO1A'
-        target='_blank'
-      >
-        <i className='fa fa-youtube-play' style={{ fontSize: `32px` }} />
-        <LinkText>Tech Talks</LinkText>
-      </Link>
-      <Link href={speakerFormLink} target='_blank'>
-        <i className='fa fa-comment' style={{ fontSize: `32px` }} />
-        <LinkText>Give a Talk</LinkText>
-      </Link>
-      <Link href='./p/code_of_conduct' target='_blank'>
-        <i className='fa fa-sticky-note' style={{ fontSize: `32px` }} />
-        <LinkText>Code of Conduct</LinkText>
-      </Link>
-      <Link href='https://pzf47fgronb.typeform.com/to/mXvf7ZJy' target='_blank'>
-        <i className="fa fa-users" style={{ fontSize: `32px` }} />
-        <LinkText>Volunteer</LinkText>
-      </Link>
-  
-    </Header>
-    <InnerContainer>
-      <TitleContainer>
-        <Title>
-          {page}&nbsp;<b style={{ color: `#ffffff` }}>JS</b>
-        </Title>
-        <Rotator
-          items={[`MEETUPS`, `TECH TALKS`, `WORKSHOPS`, `SOCIAL EVENTS`]}
-        />
-      </TitleContainer>
-      <Tower fill={backgroundColor} />
-    </InnerContainer>
-  </Container>
-)
+export default ({
+  backgroundColor = theme.primary,
+  page = `TORONTO`,
+}: Props) => {
+  return (
+    <Container backgroundColor={backgroundColor}>
+      <Header>
+        <Link
+          href="https://join.slack.com/t/torontojs/shared_invite/zt-zgi31snl-omO3tXSZ0Q7zqN9WBQSf8Q"
+          target="_blank"
+        >
+          <SlackIcon style={{ width: `30px` }} />
+          <LinkText>Join us on Slack</LinkText>
+        </Link>
+        <Link href="http://meetup.com/torontojs" target="_blank">
+          <i className="fa fa-meetup" style={{ fontSize: `32px` }} />
+          <LinkText>Join us on Meetup</LinkText>
+        </Link>
+        <Link href="https://github.com/torontojs/torontojs.com" target="_blank">
+          <Octocat width="30px" />
+          <LinkText>Contribute to this site</LinkText>
+        </Link>
+        <Link
+          href="https://www.youtube.com/channel/UC1samyyfqiKmOT6fq3uVO1A"
+          target="_blank"
+        >
+          <i className="fa fa-youtube-play" style={{ fontSize: `32px` }} />
+          <LinkText>Tech Talks</LinkText>
+        </Link>
+        <Link href={speakerFormLink} target="_blank">
+          <i className="fa fa-comment" style={{ fontSize: `32px` }} />
+          <LinkText>Give a Talk</LinkText>
+        </Link>
+        <Link href="./p/code_of_conduct" target="_blank">
+          <i className="fa fa-sticky-note" style={{ fontSize: `32px` }} />
+          <LinkText>Code of Conduct</LinkText>
+        </Link>
+        <Link
+          href="https://pzf47fgronb.typeform.com/to/mXvf7ZJy"
+          target="_blank"
+        >
+          <i className="fa fa-users" style={{ fontSize: `32px` }} />
+          <LinkText>Volunteer</LinkText>
+        </Link>
+        <Link href="./p/report" target="_blank">
+          <i className="fa fa-flag" style={{ fontSize: `32px` }} />
+          <LinkText>Report Abuse</LinkText>
+        </Link>
+      </Header>
+      <InnerContainer>
+        <TitleContainer>
+          <Title>
+            {page}&nbsp;<b style={{ color: `#ffffff` }}>JS</b>
+          </Title>
+          <Rotator
+            items={[`MEETUPS`, `TECH TALKS`, `WORKSHOPS`, `SOCIAL EVENTS`]}
+          />
+        </TitleContainer>
+        <Tower fill={backgroundColor} />
+      </InnerContainer>
+    </Container>
+  )
+}


### PR DESCRIPTION
### Changes

  - updated `README.md` with overview of repo structure to onboard possible new contributors
  - Seems like whitespace or hard returns are not handled well by `react-markdown`
  - Fix: "Report A Violation" form was not able to be submitted, nor was Typeform setup complete for some reason. I signed up for a new Typeform account with `organizers@torontojs.com` and put the credentials in our 1password.
  - Created separate page for incident reporting
  - Enhancement:  added link on navbar to `/p/report` so people don't have to scroll to the bottom of the CoC page to find it
  - The only changes are in:
     - `Splash.js`, 
     - `App.js`
     - `public/pages/code_of_conduct.md`
     - `public/pages/report.md` 
   Everything else is my linter/formatter adding whitespace 🙄 
  
  Hoping to close out this change and test that it works before the 29th JS Social
