### PR TITLE
Update Guild SDK version & Import React

### DIFF
--- a/components/guild/index.coffee
+++ b/components/guild/index.coffee
@@ -1,3 +1,5 @@
+import React from 'react'
+
 export default \
 class Guild extends React.Component
   constructor: ->
@@ -5,7 +7,6 @@ class Guild extends React.Component
     @ref ||= React.createRef()
 
   render: ->
-    return null if process.env.DISABLE_GUILD
     <div
       className={@constructor.name}
       ref={@ref}

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <link rel="manifest" href="/manifest.webmanifest">
 
     <link rel="me" href="https://mastodon.social/@torontojs" title="Mastodon account" />
-    <script src="https://guild.host/assets/0.2.0/sdk.js"></script>
+    <script src="https://guild.host/assets/0.3.0/sdk.js"></script>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
Fixes #172
Reverts #173

1. I noticed we're running an older version of the Guild SDK, so updating it here as well. The older SDK didn't have a `try ... catch` around Gravatar which resulted in that error screen. The newer SDK does, and I've added another condition to not run Gravatar in local environments
2. I also noticed we were missing the import for React on the Guild component here, which threw an error message for me after doing a fresh clone & install. Not sure if anyone else saw that too / how has this worked for others? Either way, I've imported React for the Guild component which has fixed that
3. I've remove the `DISABLE_GUILD` environment option, now that #172 is fixed