### PR TITLE
Fix mobile navigation layout with hamburger menu

### DIFF
--- a/components/navbar/index.coffee
+++ b/components/navbar/index.coffee
@@ -2,20 +2,20 @@ import React, { useState } from 'react'
 import JoinUs from '/components/join-us'
 
 import {
-  FaSlackHash,
-  FaGithub,
-  FaComment,
-  FaStickyNote,
-  FaFlag,
-  FaPenNib,
-  FaBars,
+  FaSlackHash
+  FaGithub
+  FaComment
+  FaStickyNote
+  FaFlag
+  FaPenNib
+  FaBars
   FaTimes
 } from 'react-icons/fa'
 
 import GuildLogo from './guild_logo.png'
 import './styles.sass'
 
-Navbar = ({ afterDark = false }) ->
+export default Navbar = ({ afterDark = false }) ->
   [menuOpen, setMenuOpen] = useState false
 
   <nav className="Navbar #{if afterDark then 'after-dark' else ''}">
@@ -59,4 +59,4 @@ Navbar = ({ afterDark = false }) ->
     </div>
   </nav>
 
-export default Navbar
+

--- a/components/navbar/index.coffee
+++ b/components/navbar/index.coffee
@@ -1,74 +1,62 @@
-import React from 'react'
-
+import React, { useState } from 'react'
 import JoinUs from '/components/join-us'
 
 import {
-  FaSlackHash
-  FaGithub
-  FaComment
-  FaStickyNote
-  FaFlag
-  FaPenNib
+  FaSlackHash,
+  FaGithub,
+  FaComment,
+  FaStickyNote,
+  FaFlag,
+  FaPenNib,
+  FaBars,
+  FaTimes
 } from 'react-icons/fa'
 
 import GuildLogo from './guild_logo.png'
-
 import './styles.sass'
 
-export default Navbar = ({ afterDark = false }) ->
+Navbar = ({ afterDark = false }) ->
+  [menuOpen, setMenuOpen] = useState false
+
   <nav className="Navbar #{if afterDark then 'after-dark' else ''}">
-    <JoinUs
-      button={(toggle)->
-        <a href='#'
-          onClick={toggle}
-          aria-label="Join Slack">
-          <FaSlackHash/>
-          <span className="label">
-            Join Slack
-          </span>
-        </a>
-      }
-    />
-    <a href='https://guild.host/torontojs'
-      aria-label="Join us on Guild">
-      <img src={GuildLogo} alt="logo for Guild.host"/>
-      <span className="label">
-        Join us on Guild
-      </span>
-    </a>
-    <a href='https://github.com/torontojs/torontojs.com'
-      aria-label="Github link to contribute">
-      <FaGithub/>
-      <span className="label">
-        Contribute
-      </span>
-    </a>
-    <a href='https://docs.google.com/forms/d/e/1FAIpQLSc_ZA0ElHLsMedjdQjZechw5H1RJNhG1DZxtFTsqhkdut3eFg/viewform?usp=sf_link'
-      aria-label="Give a talk">
-      <FaComment/>
-      <span className="label">
-        Give a Talk
-      </span>
-    </a>
-    <a href='/code_of_conduct'
-      aria-label="Code of Conduct">
-      <FaStickyNote/>
-      <span className="label">
-        Code of Conduct
-      </span>
-    </a>
-    <a href='/report'
-      aria-label="Report Abuse">
-      <FaFlag/>
-      <span className="label">
-        Report Abuse
-      </span>
-    </a>
-    <a href='https://blog.torontojs.com'
-      aria-label="Blog">
-      <FaPenNib/>
-      <span className="label">
-        Blog
-      </span>
-    </a>
+    <button className="menu-toggle" onClick={() -> setMenuOpen(!menuOpen)} aria-label="Toggle menu">
+      {if menuOpen then <FaTimes /> else <FaBars />}
+    </button>
+
+    <div className="nav-links #{if menuOpen then 'open' else ''}">
+      <JoinUs
+        button={(toggle) ->
+          <a href='#' onClick={toggle} aria-label="Join Slack">
+            <FaSlackHash/>
+            <span className="label">Join Slack</span>
+          </a>
+        }
+      />
+      <a href='https://guild.host/torontojs' aria-label="Join us on Guild">
+        <img src={GuildLogo} alt="logo for Guild.host"/>
+        <span className="label">Join us on Guild</span>
+      </a>
+      <a href='https://github.com/torontojs/torontojs.com' aria-label="Github link to contribute">
+        <FaGithub/>
+        <span className="label">Contribute</span>
+      </a>
+      <a href='https://docs.google.com/forms/d/e/1FAIpQLSc_ZA0ElHLsMedjdQjZechw5H1RJNhG1DZxtFTsqhkdut3eFg/viewform?usp=sf_link' aria-label="Give a talk">
+        <FaComment/>
+        <span className="label">Give a Talk</span>
+      </a>
+      <a href='/code_of_conduct' aria-label="Code of Conduct">
+        <FaStickyNote/>
+        <span className="label">Code of Conduct</span>
+      </a>
+      <a href='/report' aria-label="Report Abuse">
+        <FaFlag/>
+        <span className="label">Report Abuse</span>
+      </a>
+      <a href='https://blog.torontojs.com' aria-label="Blog">
+        <FaPenNib/>
+        <span className="label">Blog</span>
+      </a>
+    </div>
   </nav>
+
+export default Navbar

--- a/components/navbar/styles.sass
+++ b/components/navbar/styles.sass
@@ -17,6 +17,8 @@ nav.Navbar
       +fancy-link
       &:hover
         background: var(--color-night)
+    .nav-links.open
+      background: var(--color-night)
 
   a
     +fancy-link
@@ -32,6 +34,7 @@ nav.Navbar
     transition: all 350ms ease-in-out
     &:hover
       background: var(--color-red)
+      
   .menu-toggle
     display: none
     background: none
@@ -41,9 +44,7 @@ nav.Navbar
     cursor: pointer
     padding: 0.5rem
     position: absolute
-    right: 1rem
-    top: 50%
-    transform: translateY(-50%)
+    right: 0
     z-index: 2
 
   .nav-links
@@ -54,7 +55,7 @@ nav.Navbar
     height: 1em
     font-size: 1.2rem
     margin-right: 0.5rem
-    
+
   +tablet
     .menu-toggle
       display: block
@@ -69,6 +70,7 @@ nav.Navbar
       text-align: left
       z-index: 1
       box-shadow: -5px 0 10px rgba(0, 0, 0, 0.3)
+
     a
       padding: 1em
       display: flex
@@ -77,3 +79,6 @@ nav.Navbar
 
     .nav-links.open
       display: flex
+      background: var(--color-red)
+      align-items: flex-start
+ 

--- a/components/navbar/styles.sass
+++ b/components/navbar/styles.sass
@@ -43,8 +43,7 @@ nav.Navbar
     text-decoration: none
     transition: all 350ms ease-in-out
 
-    &:hover
-      background: var(--color-red-dark)
+   
 
     svg, img
       height: 1em
@@ -62,12 +61,10 @@ nav.Navbar
       position: absolute
       top: 0
       right: 0
-      background: var(--color-red)
       padding: 1em
       text-align: left
       z-index: 1
       box-shadow: -5px 0 10px rgba(0, 0, 0, 0.3) 
-
       a
         padding: 1em
         display: flex

--- a/components/navbar/styles.sass
+++ b/components/navbar/styles.sass
@@ -6,15 +6,32 @@ nav.Navbar
   background: var(--color-red)
   min-height: 40px
   display: flex
-  align-items: center
   justify-content: center
   transition: all 350ms ease-in-out
-  padding: 0 1em
-  position: relative 
-
+  position: relative
+  &:hover
+    background: var(--color-red-dark)
   &.after-dark
     background: var(--color-night)
+    a
+      +fancy-link
+      &:hover
+        background: var(--color-night)
 
+  a
+    +fancy-link
+    display: flex
+    flex-wrap: wrap
+    align-items: center
+    cursor: pointer
+    line-height: 40px
+    margin: 0
+    padding: 0 1em
+    color: inherit
+    text-decoration: none
+    transition: all 350ms ease-in-out
+    &:hover
+      background: var(--color-red)
   .menu-toggle
     display: none
     background: none
@@ -23,38 +40,25 @@ nav.Navbar
     font-size: 1.5rem
     cursor: pointer
     padding: 0.5rem
-    position: absolute 
-    right: 1rem 
-    top: 50% 
-    transform: translateY(-50%) 
+    position: absolute
+    right: 1rem
+    top: 50%
+    transform: translateY(-50%)
     z-index: 2
 
   .nav-links
     display: flex
     align-items: center
 
-  a
-    +fancy-link
-    display: flex
-    align-items: center
-    cursor: pointer
-    padding: 0 1em
-    color: inherit
-    text-decoration: none
-    transition: all 350ms ease-in-out
-
-   
-
-    svg, img
-      height: 1em
-      font-size: 1.2rem
-      margin-right: 0.5rem
-
-
+  svg, img
+    height: 1em
+    font-size: 1.2rem
+    margin-right: 0.5rem
+    
   +tablet
     .menu-toggle
       display: block
-    
+
     .nav-links
       display: none
       flex-direction: column
@@ -64,11 +68,12 @@ nav.Navbar
       padding: 1em
       text-align: left
       z-index: 1
-      box-shadow: -5px 0 10px rgba(0, 0, 0, 0.3) 
-      a
-        padding: 1em
-        display: flex
-        justify-content: flex-start 
+      box-shadow: -5px 0 10px rgba(0, 0, 0, 0.3)
+    a
+      padding: 1em
+      display: flex
+      justify-content: flex-start
+      line-height: 0
 
     .nav-links.open
       display: flex

--- a/components/navbar/styles.sass
+++ b/components/navbar/styles.sass
@@ -6,35 +6,72 @@ nav.Navbar
   background: var(--color-red)
   min-height: 40px
   display: flex
+  align-items: center
   justify-content: center
   transition: all 350ms ease-in-out
-  &:hover
-    background: var(--color-red-dark)
+  padding: 0 1em
+  position: relative 
+
   &.after-dark
     background: var(--color-night)
-    a
-      +fancy-link
-      &:hover
-        background: var(--color-night)
+
+  .menu-toggle
+    display: none
+    background: none
+    border: none
+    color: white
+    font-size: 1.5rem
+    cursor: pointer
+    padding: 0.5rem
+    position: absolute 
+    right: 1rem 
+    top: 50% 
+    transform: translateY(-50%) 
+    z-index: 2
+
+  .nav-links
+    display: flex
+    align-items: center
+
   a
     +fancy-link
-    display: block
+    display: flex
+    align-items: center
     cursor: pointer
-    line-height: 40px
-    margin: 0
     padding: 0 1em
     color: inherit
     text-decoration: none
     transition: all 350ms ease-in-out
+
     &:hover
-      background: var(--color-red)
+      background: var(--color-red-dark)
 
     svg, img
       height: 1em
       font-size: 1.2rem
-      vertical-align: sub
-      margin-right: 0.33rem
+      margin-right: 0.5rem
 
-    +tablet
-      span.label
-        display: none
+
+  +tablet
+    .menu-toggle
+      display: block
+    
+    .nav-links
+      display: none
+      flex-direction: column
+      position: absolute
+      top: 0
+      right: 0
+      background: var(--color-red)
+      padding: 1em
+      text-align: left
+      z-index: 1
+      box-shadow: -5px 0 10px rgba(0, 0, 0, 0.3) 
+
+      a
+        padding: 1em
+        display: flex
+        justify-content: flex-start 
+
+    .nav-links.open
+      display: flex


### PR DESCRIPTION
This PR improves the mobile layout for the navigation menu.
Adjustments include adding a hamburger menu with both icons and text for better clarity and navigation.
Fixes #164 
Before
<img width="316" alt="Screenshot 2025-02-23 at 12 53 13 PM" src="https://github.com/user-attachments/assets/eba7c101-45a8-4600-a859-0ba934a82a03" />
After 
<img width="317" alt="Screenshot 2025-02-23 at 1 00 37 PM" src="https://github.com/user-attachments/assets/20b4e928-ca6a-45cb-9441-c8e0832d86b4" />
<img width="318" alt="Screenshot 2025-02-23 at 1 00 09 PM" src="https://github.com/user-attachments/assets/2593521f-20ae-4404-a799-a6cc12460bba" />


