### PR TITLE
Add last commit date from patch header to JWT and Slack message

### DIFF
--- a/functions/github-callback.mjs
+++ b/functions/github-callback.mjs
@@ -30,7 +30,8 @@ const handler = async (req, context) => {
     if (!user.email) user.email = await primary_email_from_access_token(access_token)
     Sentry.setUser({id: user.github, email: user.email, username: user.name})
 
-    const token = jwt_for_user(user)
+    const last_commit_date = await commit_patch_date(access_token, user.github)
+    const token = jwt_for_user({ ...user, last_commit_date })
 
     context.cookies.set({ name: 'token', value: token, path: '/' })
 
@@ -116,6 +117,33 @@ const primary_email_from_access_token = async (access_token) => {
   const emails = await response.json()
 
   for (const { email, primary, verified } of emails) if (verified && primary) return email
+}
+
+const commit_patch_date = async (access_token, username) => {
+  const reposResponse = await fetch(`https://api.github.com/users/${username}/repos?sort=pushed&per_page=1`, {
+    headers: { "Authorization": `Bearer ${access_token}`, "Accept": "application/json" },
+  })
+  if (!reposResponse.ok) return
+  const repos = await reposResponse.json()
+  if (repos.length === 0) return
+  const { full_name } = repos[0]
+
+  const commitsResponse = await fetch(`https://api.github.com/repos/${full_name}/commits?per_page=1`, {
+    headers: { "Authorization": `Bearer ${access_token}`, "Accept": "application/json" },
+  })
+  if (!commitsResponse.ok) return
+  const commits = await commitsResponse.json()
+  if (commits.length === 0) return
+  const sha = commits[0].sha
+
+  const patchResponse = await fetch(`https://api.github.com/repos/${full_name}/commits/${sha}`, {
+    headers: { "Authorization": `Bearer ${access_token}`, "Accept": "application/vnd.github.v3.diff" },
+  })
+  if (!patchResponse.ok) return
+  const patch = await patchResponse.text()
+
+  const match = patch.match(/^Date: (.+)$/m)
+  return match ? match[1] : undefined
 }
 
 const jwt_for_user = (user) => {

--- a/functions/github-callback.mjs
+++ b/functions/github-callback.mjs
@@ -137,7 +137,7 @@ const commit_patch_date = async (access_token, username) => {
   const sha = commits[0].sha
 
   const patchResponse = await fetch(`https://api.github.com/repos/${full_name}/commits/${sha}`, {
-    headers: { "Authorization": `Bearer ${access_token}`, "Accept": "application/vnd.github.v3.diff" },
+    headers: { "Authorization": `Bearer ${access_token}`, "Accept": "application/vnd.github.v3.patch" },
   })
   if (!patchResponse.ok) return
   const patch = await patchResponse.text()

--- a/functions/request-invitation.mjs
+++ b/functions/request-invitation.mjs
@@ -61,6 +61,7 @@ const slack_payload = ({
   website,
   avatar,
   created_at,
+  last_commit_date,
 }) => {
   // {
   //   "name": "Kieran Huggins",
@@ -95,6 +96,14 @@ const slack_payload = ({
     };
   };
 
+  const commitDateLine = () => {
+    if (!last_commit_date) return "Last Commit: N/A"
+    const offsetMatch = last_commit_date.match(/([+-]\d{4})$/)
+    const offset = offsetMatch?.[1]
+    const sus = offset && !["-0400", "-0500"].includes(offset) ? " :sus:" : ""
+    return `Last Commit: ${last_commit_date}${sus}`
+  }
+
   const infoBlock = () => {
     return {
       type: "section",
@@ -104,6 +113,7 @@ const slack_payload = ({
           `Email: ${email || "undefined"}`,
           `GitHub: <https://github.com/${github}|${github}>`,
           `Created At: ${created_at || "undefined"}`,
+          commitDateLine(),
           `Company: ${company || "undefined"}`,
           `Website: ${website || "undefined"}`,
           ``,


### PR DESCRIPTION
Fetches the raw patch of the user's most recent commit during GitHub OAuth login, parses the Date line (with timezone offset) from the patch header, and stores it in the JWT as `last_commit_date`.

In the request-invitation Slack message, the commit date is displayed along with a `:sus:` indicator if the timezone offset isn't `-0400` or `-0500`.