### PR TITLE
Filter last commit by author to only return user's own commits

### DIFF
--- a/functions/github-callback.mjs
+++ b/functions/github-callback.mjs
@@ -128,7 +128,7 @@ const commit_patch_date = async (access_token, username) => {
   if (repos.length === 0) return
   const { full_name } = repos[0]
 
-  const commitsResponse = await fetch(`https://api.github.com/repos/${full_name}/commits?per_page=1`, {
+  const commitsResponse = await fetch(`https://api.github.com/repos/${full_name}/commits?author=${username}&per_page=1`, {
     headers: { "Authorization": `Bearer ${access_token}`, "Accept": "application/json" },
   })
   if (!commitsResponse.ok) return

--- a/functions/github-callback.mjs
+++ b/functions/github-callback.mjs
@@ -120,13 +120,14 @@ const primary_email_from_access_token = async (access_token) => {
 }
 
 const commit_patch_date = async (access_token, username) => {
-  const reposResponse = await fetch(`https://api.github.com/users/${username}/repos?sort=pushed&per_page=1`, {
+  const reposResponse = await fetch(`https://api.github.com/users/${username}/repos?sort=pushed&per_page=10`, {
     headers: { "Authorization": `Bearer ${access_token}`, "Accept": "application/json" },
   })
   if (!reposResponse.ok) return
   const repos = await reposResponse.json()
-  if (repos.length === 0) return
-  const { full_name } = repos[0]
+  const nonFork = repos.find(r => !r.fork)
+  if (!nonFork) return
+  const { full_name } = nonFork
 
   const commitsResponse = await fetch(`https://api.github.com/repos/${full_name}/commits?author=${username}&per_page=1`, {
     headers: { "Authorization": `Bearer ${access_token}`, "Accept": "application/json" },


### PR DESCRIPTION
Adds `author=${username}` query param to the commits API call so we only count commits actually authored by the GitHub user, not just the latest commit in their repo.